### PR TITLE
Fix for more standard handling of assert, as old one caused problems in SQLite

### DIFF
--- a/private_include/assert.h
+++ b/private_include/assert.h
@@ -1,7 +1,7 @@
 #ifndef __DUMMY_ASSERT_H
 #define __DUMMY_ASSERT_H
 #ifdef NDEBUG
-#define assert(x) 
+#define assert(x) ((void)(0))
 #else
 #include_next <assert.h>
 #endif


### PR DESCRIPTION
Previous fix: https://github.com/fedepell/sqlite/commit/c7a9ff54833e4321fe51290565b1eff9fd0f7cff
See also discussion here: https://www.sqlite.org/forum/forumpost/407828b281

Found that this was already noticed upstream but planned for 6.x: https://github.com/espressif/esp-idf/issues/10136